### PR TITLE
Default To Not Setting Hostname

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -179,3 +179,6 @@ nginx_status_port: 8890
 nginx_log_path: /var/log/nginx
 nginx_cert_path: /etc/nginx/crt
 nginx_key_path: /etc/nginx/key
+
+# hostname
+nginx_set_hostname: False

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,8 +14,9 @@ galaxy_info:
   - system
 
 dependencies:
-  - ANXS.hostname
-  - ANXS.apt
+  - role: ANXS.hostname
+    when: nginx_set_hostname == True
+  - role: ANXS.apt
   - role: ANXS.build-essential
     when: nginx_install_method is defined and nginx_install_method == "source"
   - role: ANXS.perl


### PR DESCRIPTION
Default to not calling ANXS.hostname to set the hostname since this is expected to have already been done to the host.

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>