### PR TITLE
Allow for "Raw" Variables In Site Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,18 @@ nginx_sites:
 
 The final example shows how to set multiple directives.
 
+You can prevent the role from adding a semi-colon and a carriage return after a value defined in nginx_sites by prepending two underscores (`__`) to the key:
+
+```yml
+nginx_sites:
+  - server:
+      name: foo
+      listen: 8080
+      __server_name: localhost
+```
+
+The site file for the site defined above will not have a semi-colon and carriage return added after the value for "server_name";
+
 To enable or disable specific sites you can add prior used `server_name` attribute to the variables `nginx_enabled_sites` and `nginx_disabled_sites`.
 
 ```yml

--- a/templates/site.j2
+++ b/templates/site.j2
@@ -4,10 +4,12 @@ server {
 {% if k.find('location') == -1 and k != 'name' and k != 'ssl' %}
 {% if v is not string and v is iterable %}
 {% for lv in v %}
-  {{ k }} {{ lv }};
+  {{ k|replace('__', '') }} {{ lv }}{% if k.find('__') == -1 %};
+{% endif %}
 {% endfor %}
 {% else %}
-  {{ k }} {{ v }};
+  {{ k|replace('__', '') }} {{ v }}{% if k.find('__') == -1 %};
+{% endif %}
 {% endif %}
 {% endif %}
 {% if k.find('location') == -1 and k == 'ssl' and v['enabled'] %}
@@ -20,10 +22,12 @@ server {
 {% for x,y in v.iteritems() if x != 'name' %}
 {% if y is not string and y is iterable %}
 {% for ly in y %}
-    {{ x }} {{ ly }};
+    {{ x|replace('__', '') }} {{ ly }}{% if x.find('__') == -1 %};
+{% endif %}
 {% endfor %}
 {% else %}
-    {{ x }} {{ y }};
+    {{ x|replace('__', '') }} {{ y }}{% if x.find('__') == -1 %};
+{% endif %}
 {% endif %}
 {% endfor %}
   }


### PR DESCRIPTION
Allow for marking a key in the nginx_sites variable as raw by prefixing
it with two underscores. This prevents the role from adding a semicolon
after attaching the key's value to the template.

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>