### PR TITLE
Do not use a separate SSL config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,7 @@ nginx_sites:
       name: foo
       listen: 8080
       server_name: localhost
-      ssl:
-        enabled: true
-        cert: "cert_file"
-        key: "key_file"
-        src_dir: "files"
-        conf: "foo-ssl.conf"
+      ssl: on
       location1:
         name: "/"
         try_files: "$uri $uri/ /index.html"
@@ -133,8 +128,6 @@ nginx_sites:
       name: bar
       listen: 8888
       server_name: webmail.localhost
-      ssl:
-        enabled: false
       location1:
         name: /
         try_files: "$uri $uri/ /index.html"
@@ -231,7 +224,7 @@ To the contributors:
 
 
 #### Testing
-This project comes with a VagrantFile, this is a fast and easy way to test changes to the role, fire it up with `vagrant up`. 
+This project comes with a VagrantFile, this is a fast and easy way to test changes to the role, fire it up with `vagrant up`.
 
 See [vagrant docs](https://docs.vagrantup.com/v2/) for getting setup with vagrant
 

--- a/tasks/sites.yml
+++ b/tasks/sites.yml
@@ -26,6 +26,7 @@
   with_items: "{{nginx_enabled_sites}}"
   notify:
     - reload nginx
+    - restart certbot
   when: nginx_enabled_sites|lower != 'none'
 
 - name: Nginx | Disable sites
@@ -36,8 +37,3 @@
   notify:
     - reload nginx
   when: nginx_disabled_sites|lower != 'none'
-
-- include_tasks: ssl.yml
-  vars:
-    site: "{{ item }}"
-  with_items: "{{ nginx_sites }}"

--- a/templates/site.j2
+++ b/templates/site.j2
@@ -1,7 +1,7 @@
 server {
 
 {% for k,v in item.server.iteritems() %}
-{% if k.find('location') == -1 and k != 'name' and k != 'ssl' %}
+{% if k.find('location') == -1 and k != 'name' %}
 {% if v is not string and v is iterable %}
 {% for lv in v %}
   {{ k|replace('__', '') }} {{ lv }}{% if k.find('__') == -1 %};
@@ -11,9 +11,6 @@ server {
   {{ k|replace('__', '') }} {{ v }}{% if k.find('__') == -1 %};
 {% endif %}
 {% endif %}
-{% endif %}
-{% if k.find('location') == -1 and k == 'ssl' and v['enabled'] %}
-  include /etc/nginx/{{ v['conf'] }};
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
- SSL config should not use a separate config file, allows easy certbot integration with nginx sites.
- Notify `restart certbot` handler to force certbot to apply configuration to nginx enabled site