### PR TITLE
Fix NGINX (Re)start Issue

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,9 +6,7 @@
 - name: start nginx
   service: name=nginx state=started
   become: yes
-  register: nginx_started
 
 - name: restart nginx
   service: name=nginx state=restarted
   become: yes
-  when: not nginx_first_start.changed

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -23,17 +23,6 @@
   notify:
     - restart nginx
 
-- name: Nginx | Check if Nginx is running
-  shell: "service nginx status"
-  ignore_errors: yes
-  register: nginx_started_check
-
-- name: Nginx | Notify Nginx service start
-  command: "echo Nginx service scheduled to start"
-  when: nginx_started_check.rc != 0
-  notify:
-   - start nginx
-
 - name: Nginx | Enable the Nginx service
   service:
     name: nginx


### PR DESCRIPTION
Fixes the issue causing Ansible to fail with a variable undefined error
for the "nginx_first_start" variable.

Simplifies the process by allowing both the start and restart handlers
to run in the same deployment. The start handler will however always run before the
restart handler (based on the placement in the handlers/main.yml file).

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>