### PR TITLE
Move access_log_format into ssl Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,13 +118,13 @@ nginx_sites:
       name: foo
       listen: 8080
       server_name: localhost
-      access_log_format: "{{ nginx_access_logs.0.name }}"
       ssl:
         enabled: true
         cert: "cert_file"
         key: "key_file"
         src_dir: "files"
         conf: "foo-ssl.conf"
+        access_log_format: "{{ nginx_access_logs.0.name }}"
       location1:
         name: "/"
         try_files: "$uri $uri/ /index.html"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -7,7 +7,9 @@ lint:
   name: yamllint
 platforms:
   - name: ubuntu-16.04
-    image: ubuntu:16.04
+    image: solita/ubuntu-systemd:16.04
+    privileged: true
+    command: /sbin/init
 provisioner:
   name: ansible
   lint:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -13,6 +13,11 @@
     - role: ansible-nginx
       nginx_install_method: "package"
       nginx_ssl_dir: "{{ nginx_dir }}/ssl/tests/{{ site.server.server_name }}"
+      nginx_access_logs:
+        - name: "example_com_access_format"
+          format: "$http_x_forwarded_for - $remote_user [$time_local] $status $body_bytes_sent $request_length"
+          options: null
+          filename: "access.log"
       nginx_sites:
         - server:
             name: foo
@@ -24,6 +29,7 @@
               key: "key.pem"
               src_dir: "files"
               conf: "example.org.conf"
+              access_log_format: "{{ nginx_access_logs.0.name }}"
             location1:
               name: "/"
               try_files: "$uri $uri/ /index.html"

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -58,6 +58,10 @@ def test_copied_files(host):
     assert keyFile.sha256sum == keyHsh
     assert oct(keyFile.mode) == "0600"
 
+    sslCnf = host.file("/etc/nginx/example.org.conf")
+    sslALog = "/var/log/nginx/foo-ssl-access.log example_com_access_format;"
+    assert sslALog in sslCnf.content_string
+
     # second ssl site
     certDir = host.file("/etc/nginx/ssl/tests/example2.org")
     assert certDir.exists

--- a/templates/secure_ssl.conf.j2
+++ b/templates/secure_ssl.conf.j2
@@ -1,5 +1,5 @@
 # SSL log files
-access_log    {{ nginx_log_dir }}/{{ site.server.name }}-ssl-access.log{% if site.server.access_log_format is defined %} {{ site.server.access_log_format }}{% endif %};
+access_log    {{ nginx_log_dir }}/{{ site.server.name }}-ssl-access.log{% if site.server.ssl.access_log_format is defined %} {{ site.server.ssl.access_log_format }}{% endif %};
 error_log     {{ nginx_log_dir }}/{{ site.server.name }}-ssl-error.log;
 
 # certs


### PR DESCRIPTION
Since the access_log_format variable is only used in sites that have SSL
turned on, moved it to inside the ssl map of sites.

This will prevent it from being directly placed in a site file and
causing the NGINX service to error with "an unknown directive
access_log_format".