### PR TITLE
Force creating ssl certificate and key symlink

### DIFF
--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -44,7 +44,7 @@
       src: "{{ site.server.ssl.src_dir }}/{{ site.server.ssl.cert }}"
       dest: "{{ nginx_ssl_dir }}/{{ site.server.ssl.cert }}"
       state: link
-      force: yes
+      force: true
     notify:
       - restart nginx
     when: site.server.ssl.create_symlink is defined and site.server.ssl.create_symlink == true
@@ -54,7 +54,7 @@
       src: "{{ site.server.ssl.src_dir }}/{{ site.server.ssl.key }}"
       dest: "{{ nginx_ssl_dir }}/{{ site.server.ssl.key }}"
       state: link
-      force: yes
+      force: true
     notify:
       - restart nginx
     when: site.server.ssl.create_symlink is defined and site.server.ssl.create_symlink == true

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -44,6 +44,7 @@
       src: "{{ site.server.ssl.src_dir }}/{{ site.server.ssl.cert }}"
       dest: "{{ nginx_ssl_dir }}/{{ site.server.ssl.cert }}"
       state: link
+      force: yes
     notify:
       - restart nginx
     when: site.server.ssl.create_symlink is defined and site.server.ssl.create_symlink == true
@@ -53,6 +54,7 @@
       src: "{{ site.server.ssl.src_dir }}/{{ site.server.ssl.key }}"
       dest: "{{ nginx_ssl_dir }}/{{ site.server.ssl.key }}"
       state: link
+      force: yes
     notify:
       - restart nginx
     when: site.server.ssl.create_symlink is defined and site.server.ssl.create_symlink == true


### PR DESCRIPTION
By the time we are copying the SSL certificate and key, they may not exist in the path yet. Forcing allows us to create the link and adding the file in the destination when ready.

Example use case: when building an image that has a site that uses certbot, we want to defer acquiring the ssl certificate until we have the DNS record resolving to the host. In this case, we would set all the nginx and certbot configs and disable the ssl site in the image. We'd then launch the image, run the certificate generation which would place the cert and key in the right destination, enable the ssl site and start nginx.