### PR TITLE
Reload the NGINX Service After (Re)Start Handler Fires

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,13 +1,13 @@
 ---
 # file: nginx/handlers/main.yml
-- name: reload nginx
-  service: name=nginx state=reloaded
-  become: true
-
 - name: start nginx
   service: name=nginx state=started enabled=yes use=service
   become: true
 
 - name: restart nginx
   service: name=nginx state=restarted enabled=yes use=service
+  become: true
+
+- name: reload nginx
+  service: name=nginx state=reloaded
   become: true


### PR DESCRIPTION
In cases where both the reload and either the start or restart handlers
are scheduled to fire, perform the reload task after the start and
restart handlers.

This prevents issues where the reload handler fails with an error
suggesting the PID file doesn't exist because the NGINX service isn't
running yet.

Signed-off-by: Jason Rogena <jason@rogena.me>