### PR TITLE
Don't Enable TLSv1* by Default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -182,7 +182,7 @@ nginx_status_port: 8890
 nginx_cert_path: /etc/nginx/crt
 nginx_key_path: /etc/nginx/key
 nginx_ssl_ciphers: "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"
-nginx_ssl_protocols: "TLSv1 TLSv1.1 TLSv1.2"
+nginx_ssl_protocols: "TLSv1.2"
 
 # hostname
 nginx_set_hostname: false


### PR DESCRIPTION
As recommended by Mozilla (intermediate compatibility) [1], disable
TLSv1.0 and TLSv1.1. Since some clients don't yet support TLSv1.3
(and v1.3 uses different cipher suites from v1.2) don't add TLSv1.3
to the default list of supported protocols.

Disabling TLSv1 mitigates against BEAST attacks.

1 - https://wiki.mozilla.org/Security/Server_Side_TLS

Signed-off-by: Jason Rogena <jason@rogena.me>