### PR TITLE
Add an Optional add_ssl_directive Variable in SSL Dictionary

### DIFF
--- a/templates/secure_ssl.conf.j2
+++ b/templates/secure_ssl.conf.j2
@@ -8,7 +8,9 @@ ssl_certificate_key       {{ nginx_ssl_dir }}/{{ site.server.ssl.key }};
 ssl_trusted_certificate   {{ nginx_ssl_dir }}/{{ site.server.ssl.cert }};
 
 # SSL opts
+{% if site.server.ssl.add_ssl_directive is not defined or site.server.ssl.add_ssl_directive %}
 ssl on;
+{% endif %}
 ssl_protocols             {{ nginx_ssl_protocols }};
 ssl_ciphers               "{{ nginx_ssl_ciphers }}";
 ssl_dhparam               /etc/ssl/certs/dhparam.pem;


### PR DESCRIPTION
Add an optional add_ssl_directive variable under the ssl dict to control
whether the "ssl on;" line is added to the SSL configuration file.

Signed-off-by: Jason Rogena <jason@rogena.me>