### PR TITLE
Add Support for Encrypted SSL Keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,18 @@ You can then use a generate password file in your site configuration using the `
 - `nginx_realip_addresses` - Sets the addresses to use for the http_realip configuration
 - `nginx_realip_real_ip_recursive` - If recursive search is enabled, the original client address that matches one of the trusted addresses is replaced by the last non-trusted address sent in the request header field. Can be on "on" or "off". The default is "off"
 
+###### SSL Certificate passphrase
+If your SSL key file is encrypted, you can add `ssl_password_file: "{{ nginx_ssl_passphrase_path }}"` to your site where `nginx_ssl_passphrase_path` is the file to store the passwords that NGINX will look for a password to decrypt your key. You will also need to set the passphrase to add to the password file by adding `ssl_passphrase: "yourpassphrase"` to the `ssl` object in your site configuration
+
+```yml
+ssl:
+  enabled:   true
+  src_dir: "files"
+  cert: "certfile.crt"
+  key: "keyfile.key"
+  ssl_passphrase: "mypassphrase"
+```
+
 ###### naxsi module
 - `nginx_naxsi_version` - version of the naxsi module
 

--- a/README.md
+++ b/README.md
@@ -278,14 +278,14 @@ You can then use a generate password file in your site configuration using the `
 - `nginx_realip_real_ip_recursive` - If recursive search is enabled, the original client address that matches one of the trusted addresses is replaced by the last non-trusted address sent in the request header field. Can be on "on" or "off". The default is "off"
 
 ###### SSL Certificate passphrase
-If your SSL key file is encrypted, you can add `ssl_password_file: "{{ nginx_ssl_passphrase_path }}"` to your site where `nginx_ssl_passphrase_path` is the file to store the passwords that NGINX will look for a password to decrypt your key. You will also need to set the passphrase to add to the password file by adding `ssl_passphrase: "yourpassphrase"` to the `ssl` object in your site configuration
+If your SSL key file is encrypted, you can add  `ssl_passphrase: "yourpassphrase"` to the `ssl` object in your site configuration. The role will add a passphrase in the file specified by `nginx_ssl_passphrase_path` (default is `/etc/nginx/passphrases`) which is where NGINX will look for a password that can decrypt the SSL key specified.
 
 ```yml
 ssl:
   enabled:   true
   src_dir: "files"
   cert: "certfile.crt"
-  key: "keyfile.key"
+  key: "encrypted-keyfile.key"
   ssl_passphrase: "mypassphrase"
 ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -182,6 +182,7 @@ nginx_status_port: 8890
 # secur_ssl.conf
 nginx_cert_path: /etc/nginx/crt
 nginx_key_path: /etc/nginx/key
+nginx_ssl_passphrase_path: /etc/nginx/passphrases
 nginx_ssl_ciphers: "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"
 nginx_ssl_protocols: "TLSv1.2"
 

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -59,6 +59,15 @@
       - restart nginx
     when: site.server.ssl.create_symlink is defined and site.server.ssl.create_symlink == true
 
+  - name: Add certificate passphrase to SSL passphrases file
+    lineinfile:
+      path: "{{ nginx_ssl_passphrase_path }}"
+      line: "{{ site.server.ssl.ssl_passphrase }}"
+      create: true
+    notify:
+      - restart nginx
+    when: site.server.ssl.ssl_passphrase is defined
+
   - name: Generate secure Diffie Hellman ephemeral parameters
     command: openssl dhparam -dsaparam -out /etc/ssl/certs/dhparam.pem 4096 creates=/etc/ssl/certs/dhparam.pem
   when: site.server.ssl.enabled == True

--- a/templates/secure_ssl.conf.j2
+++ b/templates/secure_ssl.conf.j2
@@ -6,6 +6,9 @@ error_log     {{ nginx_log_dir }}/{{ site.server.name }}-ssl-error.log;
 ssl_certificate           {{ nginx_ssl_dir }}/{{ site.server.ssl.cert }};
 ssl_certificate_key       {{ nginx_ssl_dir }}/{{ site.server.ssl.key }};
 ssl_trusted_certificate   {{ nginx_ssl_dir }}/{{ site.server.ssl.cert }};
+{% if site.ssl.ssl_passphrase is defined %}
+ssl_password_file         {{ nginx_ssl_passphrase_path }}
+{% endif %}
 
 # SSL opts
 {% if site.server.ssl.add_ssl_directive is not defined or site.server.ssl.add_ssl_directive %}


### PR DESCRIPTION
- Set a default file to write SSL passphrases to, that will be populated if a site defines an SSL passphrase.

- Add support for python3 passlib