### PR TITLE
Updates Default nginx_ssl_dir

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,7 +13,7 @@ nginx_uid: 33
 nginx_gid: 33
 
 nginx_dir: "/etc/nginx"
-nginx_ssl_dir: "{{ nginx_dir }}/ssl"
+nginx_ssl_dir: "{{ nginx_dir }}/ssl/{{ site.server.server_name }}"
 nginx_www_dir: "/srv/www"
 nginx_log_dir: "/var/log/nginx"
 nginx_pid: "/var/run/nginx.pid"


### PR DESCRIPTION
Updates the default nginx_ssl_dir to point to a directory within the SSL
directory that's segregated by site name.