### PR TITLE
Update role to work on LTS releases of Ubuntu

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -200,3 +200,12 @@ nginx_enable_monitoring: true
 
 # Basic authentication
 nginx_basic_auth_files: []
+
+# ANXS.apt installed packages
+nginx_apt_default_packages:
+  - python-apt-common
+  - unattended-upgrades
+  - apt-transport-https
+  - curl
+  - ca-certificates
+  - software-properties-common

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,6 +18,8 @@ dependencies:
   - role: ANXS.hostname
     when: nginx_set_hostname == True
   - role: ANXS.apt
+    vars:
+      apt_default_packages: "{{ nginx_apt_default_packages }}"
   - role: ANXS.build-essential
     when: nginx_install_method is defined and nginx_install_method == "source"
   - role: ANXS.perl

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,7 +10,9 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - all
+        - focal
+        - bionic
+        - jammy
   categories:
     - system
 

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -6,9 +6,9 @@ FROM {{ item.registry.url }}/{{ item.image }}
 FROM {{ item.image }}
 {% endif %}
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python2-dnf bash iproute2 && dnf clean all; \
-    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash iproute2 && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
-    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \
-    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates iproute2; \
-    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates iproute2 && xbps-remove -O; fi
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python3 sudo bash ca-certificates iproute2 && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python3 sudo python3-devel python3-dnf bash iproute2 && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python3 sudo yum-plugin-ovl bash iproute2 && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python3 sudo bash python3-xml iproute2 && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python3 sudo bash ca-certificates iproute2; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python3 sudo bash ca-certificates iproute2 && xbps-remove -O; fi

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,10 +10,33 @@ lint: |
   yamllint .
   flake8
 platforms:
-  - name: ubuntu-16.04
-    image: solita/ubuntu-systemd:16.04
+  - name: nginx-ubuntu-18.04
+    image: geerlingguy/docker-ubuntu1804-ansible:latest
     privileged: true
     command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    env:
+      LC_ALL: "C.UTF-8"
+      LANG: "C.UTF-8"
+  - name: nginx-ubuntu-20.04
+    image: geerlingguy/docker-ubuntu2004-ansible:latest
+    privileged: true
+    command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    env:
+      LC_ALL: "C.UTF-8"
+      LANG: "C.UTF-8"
+  - name: nginx-ubuntu-22.04
+    image: geerlingguy/docker-ubuntu2204-ansible:latest
+    privileged: true
+    command: /sbin/init
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    env:
+      LC_ALL: "C.UTF-8"
+      LANG: "C.UTF-8"
 provisioner:
   name: ansible
   lint:

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -6,12 +6,15 @@
     name:
       - python3-pycurl
       - dirmngr
+      - gnupg
     state: present
 
 - name: Nginx | Add the nginx repository
   apt_repository:
     repo: "{{ nginx_apt_ppa }}"
-  when: nginx_apt_ppa | length > 0
+  when:
+    - nginx_apt_ppa | length > 0
+    - ansible_distribution_version is version("22.04", "<")
 
 - name: Nginx | Make sure nginx is installed (package)
   apt:

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -3,7 +3,9 @@
 
 - name: Nginx | Make sure the ansible required dependencies are installed
   apt:
-    pkg: python3-pycurl
+    name:
+      - python3-pycurl
+      - dirmngr
     state: present
 
 - name: Nginx | Add the nginx repository

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -3,7 +3,7 @@
 
 - name: Nginx | Make sure the ansible required dependencies are installed
   apt:
-    pkg: python-pycurl
+    pkg: python3-pycurl
     state: present
 
 - name: Nginx | Add the nginx repository


### PR DESCRIPTION
# Changes

- Use `python3-pycurl` instead of `python-pycurl`
- Override default APT packages with existing packages
- Test role on Ubuntu 18.04, 20.04 & 22.04
- Update supported Ubuntu versions
