### PR TITLE
Remove the Deprecated SSL ON directive from SSL config

### DIFF
--- a/templates/secure_ssl.conf.j2
+++ b/templates/secure_ssl.conf.j2
@@ -11,9 +11,6 @@ ssl_password_file         {{ nginx_ssl_passphrase_path }};
 {% endif %}
 
 # SSL opts
-{% if site.server.ssl.add_ssl_directive is not defined or site.server.ssl.add_ssl_directive %}
-ssl on;
-{% endif %}
 ssl_protocols             {{ nginx_ssl_protocols }};
 ssl_ciphers               "{{ nginx_ssl_ciphers }}";
 ssl_dhparam               /etc/ssl/certs/dhparam.pem;


### PR DESCRIPTION
Remove `SSL on` directive from template to allow use of `listen 443 ssl;`